### PR TITLE
refactor timezone management

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ For ESLint are some PHPStorm/WebStorm plugins available:
 Just copy the file *vagrant/ssh_key_path.yaml.dist* to *vagrant/ssh_key_path.yaml* and uncomment the first line.
 Now fix the path to the proper ssh key path and then re-create the vagrant box.
 
+#### Custom timezone
+
+The default timezone inside the vagrant box is "UTC".
+
+In order to change it create a file called "vagrant/hieradata/local.yaml" which should look like this:
+
+``` yaml
+timezone: 'Europe/Berlin' # your custom timezone
+```
+
 ## Install
 
 The installation is really simple.

--- a/vagrant/hiera.yaml
+++ b/vagrant/hiera.yaml
@@ -6,5 +6,5 @@
     :datadir: /var/www/sententiaregum/vagrant/hieradata
 
 :hierarchy:
-  - common
   - local
+  - common

--- a/vagrant/hieradata/common.yaml
+++ b/vagrant/hieradata/common.yaml
@@ -13,8 +13,11 @@ classes:
   - sententiaregum::infrastructure::mysql
   - sententiaregum::infrastructure::redis
   - sententiaregum::infrastructure::jobs
+  - sententiaregum::infrastructure::timezone
   - sententiaregum::frontend::node
   - sententiaregum::frontend::npm
+
+timezone: 'UTC'
 
 # basic apt packages for the machine
 sententiaregum::installs::packages:
@@ -29,18 +32,13 @@ sententiaregum::installs::packages:
 # ssh entry point
 sententiaregum::ssh::entry_point: /var/www/sententiaregum
 
-# ruby
-sententiaregum::backend::ruby::version: '2.0'
-
-# mailcatcher
-sententiaregum::infrastructure::mailcatcher::dest_ip: '0.0.0.0'
-
 # capistrano plugins
 sententiaregum::deploy::capistrano::plugins::plugins:
   symfony:  {}
   composer: {}
 
-# php/composer configurations
+# backend
+sententiaregum::backend::php::composer: true
 sententiaregum::backend::php::version: '5.6'
 sententiaregum::backend::php::extensions:
   gd:     {}
@@ -53,10 +51,7 @@ sententiaregum::backend::php::extensions:
   apc:
     module_prefix: 'php-'
 
-sententiaregum::backend::php::composer: true
-sententiaregum::backend::php::timezone: UTC
-
-# server configurations
+sententiaregum::backend::server::server_aliases: '192.168.66.211'
 sententiaregum::backend::server::host_name: sententiaregum.dev
 sententiaregum::backend::server::doc_root: /var/www/sententiaregum/web
 sententiaregum::backend::server::front_controller: app_dev.php
@@ -64,7 +59,7 @@ sententiaregum::backend::server::port: 80
 sententiaregum::backend::server::modules:
   rewrite: {}
 
-sententiaregum::backend::server::server_aliases: '192.168.66.211'
+sententiaregum::backend::ruby::version: '2.0'
 
 # mysql configurations
 sententiaregum::infrastructure::mysql::databases:
@@ -79,7 +74,6 @@ sententiaregum::infrastructure::mysql::databases:
     host: localhost
     grant: ['ALL']
 
-# redis configurations
 sententiaregum::infrastructure::redis::instances:
   doctrine-cache:
     redis_port: 6900
@@ -92,7 +86,6 @@ sententiaregum::infrastructure::redis::instances:
   online-users:
     redis_port: 6904
 
-# cronjob configurations
 sententiaregum::infrastructure::jobs::schedules:
   cleanup_sessions:
     command: "php /var/www/sententiaregum/app/console ma27:auth:session-cleanup"
@@ -103,11 +96,12 @@ sententiaregum::infrastructure::jobs::schedules:
     user: vagrant
     hour: 5
 
+sententiaregum::infrastructure::mailcatcher::dest_ip: '0.0.0.0'
+
 # nodejs
 sententiaregum::frontend::node::version: 'stable'
 sententiaregum::frontend::node::make_install: false
 
-# global npm packages
 sententiaregum::frontend::npm::packages:
   - mocha
   - webpack

--- a/vagrant/manifests/site.pp
+++ b/vagrant/manifests/site.pp
@@ -1,4 +1,4 @@
-Exec { path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/sententiaregum/bin' }
+Exec { path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/sententiaregum/bin:/usr/local/node/node-default/bin' }
 Class['::apt::update'] -> Package <|
   title != 'python-software-properties'
   and title != 'software-properties-common'

--- a/vagrant/puppet.sh
+++ b/vagrant/puppet.sh
@@ -20,6 +20,7 @@ puppet module install willdurand/composer --force
 puppet module install willdurand/nodejs --force
 puppet module install thomasvandoren-redis --force
 puppet module install maestrodev/wget --force
+puppet module install saz-timezone --force
 
 # create stamp file in order to mark module install completed
 touch /etc/puppet/.vagrant-puppet-stamp

--- a/vagrant/puppet/sententiaregum/manifests/backend/php.pp
+++ b/vagrant/puppet/sententiaregum/manifests/backend/php.pp
@@ -1,7 +1,7 @@
 class sententiaregum::backend::php(
   $version    = '5.6',
   $extensions = {},
-  $timezone   = 'UTC'
+  $timezone   = hiera('timezone')
 ) {
   validate_string($version)
   validate_hash($extensions)

--- a/vagrant/puppet/sententiaregum/manifests/backend/php/composer.pp
+++ b/vagrant/puppet/sententiaregum/manifests/backend/php/composer.pp
@@ -7,7 +7,7 @@ class sententiaregum::backend::php::composer {
   }
 
   exec { 'composer install':
-    command     => '/usr/local/bin/composer install',
+    command     => 'composer install',
     cwd         => '/var/www/sententiaregum',
     user        => 'vagrant',
     environment => ['HOME=/home/vagrant'],

--- a/vagrant/puppet/sententiaregum/manifests/backend/server.pp
+++ b/vagrant/puppet/sententiaregum/manifests/backend/server.pp
@@ -26,7 +26,7 @@ class sententiaregum::backend::server(
   }
 
   exec { 'disable default site':
-    command => '/usr/sbin/a2dissite 000-default.conf',
+    command => 'a2dissite 000-default.conf',
     notify  => Service['apache2'],
     require => [
       ::Apache::Vhost[$host_name],

--- a/vagrant/puppet/sententiaregum/manifests/infrastructure/mailcatcher.pp
+++ b/vagrant/puppet/sententiaregum/manifests/infrastructure/mailcatcher.pp
@@ -13,7 +13,7 @@ class sententiaregum::infrastructure::mailcatcher($dest_ip) {
 
   if !$is_mailcatcher_running {
     exec { 'start mailcatcher':
-      command => "/usr/local/bin/mailcatcher --http-ip ${dest_ip}",
+      command => "mailcatcher --http-ip ${dest_ip}",
       require => [
         Package['mailcatcher'],
       ],

--- a/vagrant/puppet/sententiaregum/manifests/infrastructure/timezone.pp
+++ b/vagrant/puppet/sententiaregum/manifests/infrastructure/timezone.pp
@@ -1,0 +1,7 @@
+class sententiaregum::infrastructure::timezone($zone = hiera('timezone')) {
+  validate_string($zone)
+
+  class { '::timezone':
+    timezone => $zone,
+  }
+}


### PR DESCRIPTION
- timezone configurable through hiera
- php manifest uses hiera default as timezone
- refactor $PATH management for commands executed inside puppet

resolves #166 
