### PR TITLE
Bug #237 enhance auth attempt computation in order to avoid unnecessary warnings and false-positives

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,6 +11,5 @@ disabled:
 enabled:
   - align_equals
   - php_unit_construct
-  - php_unit_strict
   - strict_param
   - strict

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -41,6 +41,8 @@ doctrine:
         dbname:   "%database_name%"
         user:     "%database_user%"
         password: "%database_password%"
+        types:
+            date_time_array: "AppBundle\\Type\\DateTimeArrayType"
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         entity_managers:
@@ -49,7 +51,7 @@ doctrine:
                     User:
                         type:      annotation
                         is_bundle: false
-                        dir:       %kernel.root_dir%/../src/AppBundle/Model/User
+                        dir:       "%kernel.root_dir%/../src/AppBundle/Model/User"
                         alias:     Account
                         prefix:    AppBundle\Model\User
 
@@ -127,6 +129,6 @@ guzzle:
 # DoctrineMigrations Configuration
 doctrine_migrations:
     dir_name:   "%kernel.root_dir%/migrations"
-    namespace:  "Sententiaregum\Migrations"
+    namespace:  "Sententiaregum\\Migrations"
     table_name: "sententiaregum_migrations"
     name:       "Sententiaregum Migrations"

--- a/src/AppBundle/AppBundle.php
+++ b/src/AppBundle/AppBundle.php
@@ -30,7 +30,7 @@ class AppBundle extends Bundle
         // will be executed right after the extension will be loaded if available.
         $fileLoader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Resources/config'));
 
-        foreach (['services', 'validators', 'redis', 'listeners', 'repositories'] as $baseName) {
+        foreach (['services', 'validators', 'redis', 'listeners', 'repositories', 'commands'] as $baseName) {
             $fileLoader->load(sprintf('%s.yml', $baseName));
         }
     }

--- a/src/AppBundle/Behat/UsersContext.php
+++ b/src/AppBundle/Behat/UsersContext.php
@@ -13,8 +13,10 @@
 namespace AppBundle\Behat;
 
 use AppBundle\Model\User\User;
+use AppBundle\Model\User\Util\DateTimeComparison;
 use Assert\Assertion;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\TableNode;
 
 /**
  * Feature context for user repository.
@@ -103,5 +105,52 @@ class UsersContext extends FixtureLoadingContext implements SnippetAcceptingCont
     public function iShouldSeeTheUserWithId($arg1)
     {
         Assertion::eq((int) $arg1, $this->user->getId());
+    }
+
+    /**
+     * @Given the following auth data exist:
+     */
+    public function theFollowingAuthDataExist(TableNode $table)
+    {
+        foreach ($table->getHash() as $row) {
+            $user   = $row['affected'];
+            $entity = $this->getEntityManager()->getRepository('Account:User')->findOneBy(['username' => $user]);
+            $entity->addFailedAuthenticationWithIp($row['ip']);
+
+            $this->getEntityManager()->persist($entity);
+            $this->getEntityManager()->flush();
+
+            $uid  = $entity->getId();
+            $conn = $this->getEntityManager()->getConnection();
+
+            $query = $conn
+                ->prepare("SELECT `attemptId` FROM `FailedAuthAttempt2User` WHERE `userId` = :id");
+
+            $query->execute([':id' => $uid]);
+            $attemptId = $query->fetch()['attemptId'];
+
+            $query = $conn->prepare("UPDATE `authentication_attempt` SET `latest_date_time` = :latest WHERE `id` = :id");
+            $query->execute([':latest' => $row['latest'], ':id' => $attemptId]);
+        }
+    }
+
+    /**
+     * @When I delete ancient auth data
+     */
+    public function iDeleteAncientAuthData()
+    {
+        /** @var \AppBundle\Model\User\UserRepository $userRepository */
+        $userRepository = $this->getRepository('Account:User');
+        $userRepository->deleteAncientAttemptData(new \DateTime('-6 months'));
+    }
+
+    /**
+     * @Then no log about :arg1 should exist on user :arg2 should exist
+     */
+    public function noLogAboutShouldExist($arg1, $arg2)
+    {
+        Assertion::false(
+            $this->getRepository('Account:User')->findOneBy(['username' => $arg2])->exceedsIpFailedAuthAttemptMaximum($arg1, new DateTimeComparison())
+        );
     }
 }

--- a/src/AppBundle/Behat/UsersContext.php
+++ b/src/AppBundle/Behat/UsersContext.php
@@ -124,12 +124,12 @@ class UsersContext extends FixtureLoadingContext implements SnippetAcceptingCont
             $conn = $this->getEntityManager()->getConnection();
 
             $query = $conn
-                ->prepare("SELECT `attemptId` FROM `FailedAuthAttempt2User` WHERE `userId` = :id");
+                ->prepare('SELECT `attemptId` FROM `FailedAuthAttempt2User` WHERE `userId` = :id');
 
             $query->execute([':id' => $uid]);
             $attemptId = $query->fetch()['attemptId'];
 
-            $query = $conn->prepare("UPDATE `authentication_attempt` SET `latest_date_time` = :latest WHERE `id` = :id");
+            $query = $conn->prepare('UPDATE `authentication_attempt` SET `latest_date_time` = :latest WHERE `id` = :id');
             $query->execute([':latest' => $row['latest'], ':id' => $attemptId]);
         }
     }

--- a/src/AppBundle/Command/PurgeAncientAuthAttemptDataCommand.php
+++ b/src/AppBundle/Command/PurgeAncientAuthAttemptDataCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Command;
+
+use AppBundle\Model\User\UserRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Purger command which removes ancient auth attempt logs.
+ *
+ * Every attempt log item which hasn't been modified for at least ~6 months will be seen
+ * as not relevant anymore and ancient and will be removed therefore.
+ *
+ * The attempt models are lightweight items counting failed authentications of a certain IP against
+ * a user account, but if no failed authentications from an API do happen anymore or due to a false-positive
+ * in the code which erases IPs from the blacklist when the login succeeds, the log is obsolete
+ * and must be removed.
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class PurgeAncientAuthAttemptDataCommand extends Command
+{
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * Constructor.
+     *
+     * @param UserRepository $userRepository
+     */
+    public function __construct(UserRepository $userRepository)
+    {
+        parent::__construct();
+
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sententiaregum:purge:ancient-auth-attempt-log-data')
+            ->setDescription('Purges all the ancient auth attempt log items')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> purges all ancient auth attmpt log items that are older than a half year.
+
+It searches for ancient models and deletes them in one big transaction.
+
+It is recommended to run that as a cron job.
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $rule = new \DateTime('-6 months');
+
+        $amount = $this->userRepository->deleteAncientAttemptData($rule);
+        $output->writeln(sprintf(
+            '<fg=green;bg=black>Successfully purged <comment>%d</comment> ancient auth models.</fg=green;bg=black>',
+            $amount
+        ));
+
+        return 0;
+    }
+}

--- a/src/AppBundle/Command/PurgeAncientAuthAttemptDataCommand.php
+++ b/src/AppBundle/Command/PurgeAncientAuthAttemptDataCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Purger command which removes ancient auth attempt logs.
  *
  * Every attempt log item which hasn't been modified for at least ~6 months will be seen
- * as not relevant anymore and ancient and will be removed therefore.
+ * as not relevant anymore and will be removed therefore.
  *
  * The attempt models are lightweight items counting failed authentications of a certain IP against
  * a user account, but if no failed authentications from an API do happen anymore or due to a false-positive

--- a/src/AppBundle/Command/PurgeOutdatedPendingActivationsCommand.php
+++ b/src/AppBundle/Command/PurgeOutdatedPendingActivationsCommand.php
@@ -38,7 +38,7 @@ The <info>%command.name%</info> purges all pending activations that are older th
 It loads all pending activations and deletes them in one big transaction.
 When this command runs, it is not possible to activate a user that is scheduled for deletion inside doctrine.
 
-It is recommended to run that as a cron job.k
+It is recommended to run that as a cron job.
 EOF
             );
     }
@@ -54,7 +54,7 @@ EOF
 
         $amount = $userRepository->deletePendingActivationsByDate($dateTimeRule);
         $output->writeln(sprintf(
-            '<fg=green;bg=black>Successfully purged <comment>%d</comment> pending activations</fg=green;bg=black>',
+            '<fg=green;bg=black>Successfully purged <comment>%d</comment> pending activations.</fg=green;bg=black>',
             $amount
         ));
 

--- a/src/AppBundle/Features/user/users.feature
+++ b/src/AppBundle/Features/user/users.feature
@@ -25,3 +25,13 @@ Feature: user repository
             | 1       | Ma27     | 123456   | test@localhost | 1234key1234    | true             |
         When I'd like to see a user by with username "Ma27" and key "1234key1234"
         Then I should see the user with id "1"
+
+    Scenario: delete ancient attempt information
+        Given the following users exist:
+            | username | password | email                   | is_non_activated |
+            | Ma27     | 123456   | ma27@sententiaregum.dev | false            |
+        And the following auth data exist:
+            | ip        | latest              | affected |
+            | 127.0.0.1 | 2015-01-01 00:00:00 | Ma27     |
+        When I delete ancient auth data
+        Then no log about "127.0.0.1" should exist on user "Ma27" should exist

--- a/src/AppBundle/Model/User/AuthenticationAttempt.php
+++ b/src/AppBundle/Model/User/AuthenticationAttempt.php
@@ -51,6 +51,20 @@ class AuthenticationAttempt
     private $attemptCount = 0;
 
     /**
+     * @var \DateTime[]
+     *
+     * @ORM\Column(name="last_date_time_range", type="date_time_array")
+     */
+    private $lastDateTimeRange = [];
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="latest_date_time", type="datetime")
+     */
+    private $latestDateTime;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -111,6 +125,35 @@ class AuthenticationAttempt
     {
         ++$this->attemptCount;
 
+        $now                  = new \DateTime();
+        $this->latestDateTime = $now;
+
+        if (count($this->lastDateTimeRange) === (User::MAX_FAILED_ATTEMPTS_FROM_IP + 1)) {
+            array_pop($this->lastDateTimeRange);
+        }
+
+        array_unshift($this->lastDateTimeRange, $now);
+
         return $this;
+    }
+
+    /**
+     * Getter for the last datetime of a failed auth attempt.
+     *
+     * @return \DateTime
+     */
+    public function getLatestFailedAttemptTime()
+    {
+        return $this->latestDateTime;
+    }
+
+    /**
+     * Getter for the last datetime items.
+     *
+     * @return \DateTime[]
+     */
+    public function getLastFailedAttemptTimesInRange()
+    {
+        return $this->lastDateTimeRange;
     }
 }

--- a/src/AppBundle/Model/User/User.php
+++ b/src/AppBundle/Model/User/User.php
@@ -12,6 +12,7 @@
 
 namespace AppBundle\Model\User;
 
+use AppBundle\Model\User\Util\DateTimeComparison;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
@@ -397,7 +398,7 @@ class User implements UserInterface, Serializable
     public function setState($state)
     {
         if (!in_array($state, [self::STATE_NEW, self::STATE_APPROVED], true)) {
-            throw new \InvalidArgumentException(sprintf('Invalid state!'));
+            throw new \InvalidArgumentException('Invalid state!');
         }
 
         $this->state = (string) $state;
@@ -547,7 +548,7 @@ class User implements UserInterface, Serializable
 
         if ($this->hasRole($role)) {
             throw new \LogicException(sprintf(
-                'Role "%s" already in user by user "%s"!',
+                'Role "%s" already attached at user "%s"!',
                 $role->getRole(),
                 $this->getUsername()
             ));
@@ -715,11 +716,12 @@ class User implements UserInterface, Serializable
     /**
      * Checks whether the user ip is new and if true it will be persisted.
      *
-     * @param string $ip
+     * @param string             $ip
+     * @param DateTimeComparison $comparison
      *
      * @return bool
      */
-    public function isNewUserIp($ip)
+    public function addAndValidateNewUserIp($ip, DateTimeComparison $comparison)
     {
         if (!($isKnown = $this->isKnownIp($ip))) {
             $attempt = new AuthenticationAttempt();
@@ -728,13 +730,15 @@ class User implements UserInterface, Serializable
                 ->increaseAttemptCount();
 
             $this->authentications->add($attempt);
+            $this->eraseKnownIpFromBadIPList($ip, $comparison);
         }
 
         return !$isKnown;
     }
 
     /**
-     * Adds one ip of a failed authentication unless its authentication succeeded previously (users may mistype some times).
+     * Adds one ip of a failed authentication unless its authentication succeeded previously (users may mistype some
+     * times).
      *
      * @param string $ip
      *
@@ -743,15 +747,14 @@ class User implements UserInterface, Serializable
     public function addFailedAuthenticationWithIp($ip)
     {
         if (!$this->isKnownIp($ip)) {
-            if ($attempt = $this->getAuthAttemptModelByIp($ip, self::FAILED_AUTH_POOL)) {
-                $attempt->increaseAttemptCount();
-            } else {
+            if (!($attempt = $this->getAuthAttemptModelByIp($ip, self::FAILED_AUTH_POOL))) {
                 $attempt = new AuthenticationAttempt();
                 $attempt->setIp($ip);
-                $attempt->increaseAttemptCount();
 
                 $this->failedAuthentications->add($attempt);
             }
+
+            $attempt->increaseAttemptCount();
         }
 
         return $this;
@@ -760,23 +763,18 @@ class User implements UserInterface, Serializable
     /**
      * Checks if one ip exceeds the attempt count.
      *
-     * @param string $ip
+     * @param string             $ip
+     * @param DateTimeComparison $comparison
      *
      * @return bool
      */
-    public function exceedsIpFailedAuthAttemptMaximum($ip)
+    public function exceedsIpFailedAuthAttemptMaximum($ip, DateTimeComparison $comparison)
     {
         if (!$this->isKnownIp($ip, self::FAILED_AUTH_POOL)) {
             return false;
         }
 
-        $model  = $this->getAuthAttemptModelByIp($ip, self::FAILED_AUTH_POOL);
-        $result = self::MAX_FAILED_ATTEMPTS_FROM_IP <= $model->getAttemptCount();
-        if ($result) {
-            $this->failedAuthentications->removeElement($model);
-        }
-
-        return $result;
+        return $this->needsAuthWarning($this->getAuthAttemptModelByIp($ip, self::FAILED_AUTH_POOL), $comparison);
     }
 
     /**
@@ -882,5 +880,75 @@ class User implements UserInterface, Serializable
         }
 
         return $authAttempt;
+    }
+
+    /**
+     * Checks if enough failed authentications are done in the past to rise an auth warning.
+     *
+     * @param AuthenticationAttempt $attempt
+     * @param DateTimeComparison    $comparison
+     *
+     * @return bool
+     */
+    private function needsAuthWarning(AuthenticationAttempt $attempt, DateTimeComparison $comparison)
+    {
+        $count = $attempt->getAttemptCount();
+        if (self::MAX_FAILED_ATTEMPTS_FROM_IP <= $count) {
+            if (($count - 3) === 0) {
+                return true;
+            }
+
+            return !$this->isPreviouslyLoginFailed('-6 hours', $comparison, true, $attempt->getIp());
+        }
+
+        return false;
+    }
+
+    /**
+     * Erases user IPs from the blacklist.
+     *
+     * @param string             $ip
+     * @param DateTimeComparison $comparison
+     */
+    private function eraseKnownIpFromBadIPList($ip, DateTimeComparison $comparison)
+    {
+        if ($this->isPreviouslyLoginFailed('-10 minutes', $comparison)) {
+            // if it failed before the login, the login may be corrupted,
+            // there the information should be kept. The next login won't erase it although there may
+            // be a corruption since this will be called at the first login with a new IP only
+            return;
+        }
+
+        /** @var AuthenticationAttempt $model */
+        foreach ($this->failedAuthentications->toArray() as $model) {
+            if ($ip === $model->getIp()) {
+                $this->failedAuthentications->removeElement($model);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Checks if the auth failed previously.
+     *
+     * @param string             $diff
+     * @param bool               $ignoreLastAttempts
+     * @param DateTimeComparison $comparison
+     * @param string             $ip
+     *
+     * @return bool
+     */
+    private function isPreviouslyLoginFailed($diff, DateTimeComparison $comparison, $ignoreLastAttempts = false, $ip = null)
+    {
+        return $this->failedAuthentications->exists(
+            function ($index, AuthenticationAttempt $failedAttempt) use ($diff, $ignoreLastAttempts, $ip, $comparison) {
+                return $comparison(
+                    $diff,
+                    $failedAttempt->getIp() && $ignoreLastAttempts
+                        ? end($failedAttempt->getLastFailedAttemptTimesInRange())
+                        : $failedAttempt->getLatestFailedAttemptTime()
+                );
+            }
+        );
     }
 }

--- a/src/AppBundle/Model/User/User.php
+++ b/src/AppBundle/Model/User/User.php
@@ -942,11 +942,11 @@ class User implements UserInterface, Serializable
     {
         return $this->failedAuthentications->exists(
             function ($index, AuthenticationAttempt $failedAttempt) use ($diff, $ignoreLastAttempts, $ip, $comparison) {
+                $ipRange = $failedAttempt->getLastFailedAttemptTimesInRange();
+
                 return $comparison(
                     $diff,
-                    $failedAttempt->getIp() && $ignoreLastAttempts
-                        ? end($failedAttempt->getLastFailedAttemptTimesInRange())
-                        : $failedAttempt->getLatestFailedAttemptTime()
+                    $failedAttempt->getIp() && $ignoreLastAttempts ? end($ipRange) : $failedAttempt->getLatestFailedAttemptTime()
                 );
             }
         );

--- a/src/AppBundle/Model/User/UserRepository.php
+++ b/src/AppBundle/Model/User/UserRepository.php
@@ -103,7 +103,7 @@ class UserRepository extends EntityRepository
 
         $ids = array_column($idQuery->getResult(), 'id');
 
-        if ($ids) {
+        if (!empty($ids)) {
             $connection    = $this->_em->getConnection();
             $list          = implode(',', array_fill(0, count($ids), '?'));
             $relationQuery = $connection->prepare("DELETE FROM `FailedAuthAttempt2User` WHERE `attemptId` IN ({$list})");

--- a/src/AppBundle/Model/User/UserRepository.php
+++ b/src/AppBundle/Model/User/UserRepository.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 
 /**
  * Repository that contains custom dql calls for the user model.
@@ -47,18 +46,20 @@ class UserRepository extends EntityRepository
             // The activation must be done before that.
             $connection->beginTransaction();
 
-            $query = $this->queryUserIdsWithPendingActivation($dateTime);
+            $query = $this->buildQueryForUserIdsWithOldPendingActivations($dateTime);
             $query->setHydrationMode(Query::HYDRATE_ARRAY);
-            $paginator = new Paginator($query);
 
-            $qb = $this->_em->createQueryBuilder();
+            $qb       = $this->_em->createQueryBuilder();
+            $affected = 0;
 
-            $qb
-                ->delete('Account:User', 'user')
-                ->where($qb->expr()->in('user.id', ':ids'))
-                ->setParameter(':ids', iterator_to_array($paginator));
+            if ($ids = $query->getResult()) {
+                $qb
+                    ->delete('Account:User', 'user')
+                    ->where($qb->expr()->in('user.id', ':ids'))
+                    ->setParameter(':ids', $ids);
 
-            $affected = $qb->getQuery()->execute();
+                $affected = $qb->getQuery()->execute();
+            }
 
             $connection->commit();
 
@@ -68,6 +69,61 @@ class UserRepository extends EntityRepository
 
             throw $ex;
         }
+    }
+
+    /**
+     * Deletes all attempt models containing failed attempts which are too old.
+     *
+     * @param DateTime $dateTime
+     *
+     * @return int
+     */
+    public function deleteAncientAttemptData(DateTime $dateTime)
+    {
+        $qb     = $this->_em->createQueryBuilder();
+        $search = clone $qb;
+        $expr   = $qb->expr();
+
+        // unfortunately DQL can't do joins on DELETE queries
+        $idQuery = $search
+            ->select('authentication_attempt.id')
+            ->distinct()
+            ->from('Account:AuthenticationAttempt', 'authentication_attempt')
+            ->join('Account:User', 'user', Join::WITH, $expr->isMemberOf(
+                'authentication_attempt',
+                'user.failedAuthentications'
+            ))
+            ->where($expr->lt(
+                'authentication_attempt.latestDateTime',
+                ':date_time'
+            ))
+            ->setParameter(':date_time', $dateTime, Type::DATETIME)
+            ->getQuery()
+            ->setHydrationMode(Query::HYDRATE_ARRAY);
+
+        $ids = array_column($idQuery->getResult(), 'id');
+
+        if ($ids) {
+            $connection    = $this->_em->getConnection();
+            $list          = implode(',', array_fill(0, count($ids), '?'));
+            $relationQuery = $connection->prepare("DELETE FROM `FailedAuthAttempt2User` WHERE `attemptId` IN ({$list})");
+
+            // drop relations manually before removing the models
+            $result = $relationQuery->execute($ids);
+
+            if ($result) {
+                $affected = $qb
+                    ->delete('Account:AuthenticationAttempt', 'attempt')
+                    ->where($expr->in('attempt.id', ':ids'))
+                    ->setParameter(':ids', $ids)
+                    ->getQuery()
+                    ->execute();
+
+                return $affected + $result;
+            }
+        }
+
+        return 0;
     }
 
     /**
@@ -114,7 +170,7 @@ class UserRepository extends EntityRepository
      *
      * @return Query
      */
-    private function queryUserIdsWithPendingActivation(DateTime $dateTime)
+    private function buildQueryForUserIdsWithOldPendingActivations(DateTime $dateTime)
     {
         $qb = $this->_em->createQueryBuilder();
 

--- a/src/AppBundle/Model/User/Util/DateTimeComparison.php
+++ b/src/AppBundle/Model/User/Util/DateTimeComparison.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Model\User\Util;
+
+/**
+ * Simple domain service which utilizes the datetime comparison behavior.
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class DateTimeComparison
+{
+    /**
+     * Executes the datetime comparison.
+     *
+     * @param string    $maximumRange
+     * @param \DateTime $attemptDate
+     *
+     * @return bool
+     */
+    public function __invoke($maximumRange, \DateTime $attemptDate)
+    {
+        return (new \DateTime($maximumRange))->getTimestamp() <= $attemptDate->getTimestamp();
+    }
+}

--- a/src/AppBundle/Resources/config/commands.yml
+++ b/src/AppBundle/Resources/config/commands.yml
@@ -1,0 +1,7 @@
+services:
+  app.command.purge_ancient_auth_attempt:
+    class: AppBundle\Command\PurgeAncientAuthAttemptDataCommand
+    arguments:
+      - "@app.repository.user"
+    tags:
+      - { name: console.command }

--- a/src/AppBundle/Resources/config/listeners.yml
+++ b/src/AppBundle/Resources/config/listeners.yml
@@ -45,5 +45,6 @@ services:
       - "@event_dispatcher"
       - "@request_stack"
       - "@app.ip.tracer"
+      - "@app.user.service.date_time_comparator"
     tags:
       - { name: kernel.event_subscriber }

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -35,3 +35,5 @@ services:
     class: AppBundle\View\I18nResponseFormatBuilder
     arguments:
       - "@translator"
+  app.user.service.date_time_comparator:
+    class: AppBundle\Model\User\Util\DateTimeComparison

--- a/src/AppBundle/Tests/Command/PurgeAncientAuthAttemptDataCommandTest.php
+++ b/src/AppBundle/Tests/Command/PurgeAncientAuthAttemptDataCommandTest.php
@@ -24,7 +24,6 @@ class PurgeAncientAuthAttemptDataCommandTest extends \PHPUnit_Framework_TestCase
         $repoMock = $this->getMockWithoutInvokingTheOriginalConstructor(UserRepository::class);
         $repoMock->expects($this->once())
             ->method('deleteAncientAttemptData')
-            ->with(new \DateTime('-6 months'))
             ->willReturn(5);
 
         $application = new Application();

--- a/src/AppBundle/Tests/Command/PurgeAncientAuthAttemptDataCommandTest.php
+++ b/src/AppBundle/Tests/Command/PurgeAncientAuthAttemptDataCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Tests\Command;
+
+use AppBundle\Command\PurgeAncientAuthAttemptDataCommand;
+use AppBundle\Model\User\UserRepository;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PurgeAncientAuthAttemptDataCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPurgeAuthAttemptData()
+    {
+        $repoMock = $this->getMockWithoutInvokingTheOriginalConstructor(UserRepository::class);
+        $repoMock->expects($this->once())
+            ->method('deleteAncientAttemptData')
+            ->with(new \DateTime('-6 months'))
+            ->willReturn(5);
+
+        $application = new Application();
+        $command     = new PurgeAncientAuthAttemptDataCommand($repoMock);
+
+        $application->add($command);
+
+        $commandTester = new CommandTester($application->find('sententiaregum:purge:ancient-auth-attempt-log-data'));
+        $commandTester->execute(['command' => 'sententiaregum:purge:ancient-auth-attempt-log-data']);
+
+        $display = $commandTester->getDisplay();
+        $code    = $commandTester->getStatusCode();
+
+        $this->assertSame(0, $code);
+        $this->assertRegExp('/Successfully purged 5 ancient auth models\./', $display);
+    }
+}

--- a/src/AppBundle/Tests/EventListener/CredentialNotifyListenerTest.php
+++ b/src/AppBundle/Tests/EventListener/CredentialNotifyListenerTest.php
@@ -16,6 +16,7 @@ use AppBundle\EventListener\CredentialNotifyListener;
 use AppBundle\Model\Ip\Tracer\IpTracingServiceInterface;
 use AppBundle\Model\Ip\Value\IpLocation;
 use AppBundle\Model\User\User;
+use AppBundle\Model\User\Util\DateTimeComparison;
 use Doctrine\ORM\EntityManagerInterface;
 use Ma27\ApiKeyAuthenticationBundle\Event\OnAuthenticationEvent;
 use Ma27\ApiKeyAuthenticationBundle\Event\OnInvalidCredentialsEvent;
@@ -53,10 +54,10 @@ class CredentialNotifyListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getIpLocationData')
             ->willReturn(new IpLocation('127.0.0.1', 'Germany', 'Bavaria', 'Munich', 48, 11));
 
-        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer);
+        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer, new DateTimeComparison());
         $listener->onAuthentication(new OnAuthenticationEvent($user));
 
-        $this->assertFalse($user->isNewUserIp('127.0.0.1'));
+        $this->assertFalse($user->addAndValidateNewUserIp('127.0.0.1', new DateTimeComparison()));
     }
 
     public function testNotifyOnMultipleAuthAttempts()
@@ -89,10 +90,8 @@ class CredentialNotifyListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getIpLocationData')
             ->willReturn(new IpLocation('127.0.0.1', 'Germany', 'Bavaria', 'Munich', 48, 11));
 
-        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer);
+        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer, new DateTimeComparison());
         $listener->onFailedAuthentication(new OnInvalidCredentialsEvent($user));
-
-        $this->assertFalse($user->exceedsIpFailedAuthAttemptMaximum('127.0.0.1'));
     }
 
     public function testNoNotificationIfUsernameIsWrong()
@@ -116,7 +115,7 @@ class CredentialNotifyListenerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->never())
             ->method('getIpLocationData');
 
-        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer);
+        $listener = new CredentialNotifyListener($entityManager, $eventDispatcher, $stack, $tracer, new DateTimeComparison());
         $listener->onFailedAuthentication(new OnInvalidCredentialsEvent());
     }
 }

--- a/src/AppBundle/Tests/Model/User/AuthenticationAttemptTest.php
+++ b/src/AppBundle/Tests/Model/User/AuthenticationAttemptTest.php
@@ -42,7 +42,8 @@ class AuthenticationAttemptTest extends \PHPUnit_Framework_TestCase
             $fixtureData[] = $model->getLatestFailedAttemptTime();
         }
 
-        $this->assertNotSame($fixtureData[0], end($model->getLastFailedAttemptTimesInRange()));
-        $this->assertSame($fixtureData[1], end($model->getLastFailedAttemptTimesInRange()));
+        $range = $model->getLastFailedAttemptTimesInRange();
+        $this->assertNotSame($fixtureData[0], end($range));
+        $this->assertSame($fixtureData[1], end($range));
     }
 }

--- a/src/AppBundle/Tests/Model/User/AuthenticationAttemptTest.php
+++ b/src/AppBundle/Tests/Model/User/AuthenticationAttemptTest.php
@@ -21,8 +21,28 @@ class AuthenticationAttemptTest extends \PHPUnit_Framework_TestCase
         $attempt = new AuthenticationAttempt();
         $this->assertSame(0, $attempt->getAttemptCount());
 
-        $attempt->increaseAttemptCount()->increaseAttemptCount();
+        $attempt
+            ->increaseAttemptCount()
+            ->increaseAttemptCount();
 
         $this->assertSame(2, $attempt->getAttemptCount());
+        $this->assertCount(2, $attempt->getLastFailedAttemptTimesInRange());
+
+        $this->assertSame($attempt->getLatestFailedAttemptTime(), $attempt->getLastFailedAttemptTimesInRange()[0]);
+    }
+
+    /**
+     * @depends testIncreaseCount
+     */
+    public function testPopLatest()
+    {
+        $model = new AuthenticationAttempt();
+        for ($fixtureData = [], $i = 0; $i < 5; $i++) {
+            $model->increaseAttemptCount();
+            $fixtureData[] = $model->getLatestFailedAttemptTime();
+        }
+
+        $this->assertNotSame($fixtureData[0], end($model->getLastFailedAttemptTimesInRange()));
+        $this->assertSame($fixtureData[1], end($model->getLastFailedAttemptTimesInRange()));
     }
 }

--- a/src/AppBundle/Tests/Model/User/UserTest.php
+++ b/src/AppBundle/Tests/Model/User/UserTest.php
@@ -241,6 +241,15 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($user->exceedsIpFailedAuthAttemptMaximum($ip, $mock));
     }
 
+    public function testAuthCheckForNonRegisteredIP()
+    {
+        $user = User::create('Ma27', '123456', 'foo@bar.de');
+
+        $this->assertFalse(
+            $user->exceedsIpFailedAuthAttemptMaximum('127.0.0.1', $this->getMock(DateTimeComparison::class))
+        );
+    }
+
     public function testSerialization()
     {
         $user = User::create('Ma27', 'foo', 'foo@bar.de');

--- a/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
+++ b/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
@@ -42,11 +42,6 @@ class DateTimeComparisonTest extends \PHPUnit_Framework_TestCase
                 new \DateTime('-12 hours'),
                 false,
             ],
-            [
-                '-12 hours',
-                new \DateTime('-12 hours'),
-                false,
-            ],
         ];
     }
 }

--- a/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
+++ b/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Tests\Model\User\Util;
+
+use AppBundle\Model\User\Util\DateTimeComparison;
+
+class DateTimeComparisonTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string    $diff
+     * @param \DateTime $dateTime
+     * @param bool      $expected
+     *
+     * @dataProvider provideDateDiffComparison
+     */
+    public function testDateDiffComparison($diff, \DateTime $dateTime, $expected)
+    {
+        $service = new DateTimeComparison();
+        $this->assertSame($service($diff, $dateTime), $expected);
+    }
+
+    public function provideDateDiffComparison()
+    {
+        return [
+            [
+                '-12 hours',
+                new \DateTime('-6 hours'),
+                true,
+            ],
+            [
+                '-6 hours',
+                new \DateTime('-12 hours'),
+                false,
+            ],
+            [
+                '-12 hours',
+                new \DateTime('-12 hours'),
+                true,
+            ],
+        ];
+    }
+}

--- a/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
+++ b/src/AppBundle/Tests/Model/User/Util/DateTimeComparisonTest.php
@@ -45,7 +45,7 @@ class DateTimeComparisonTest extends \PHPUnit_Framework_TestCase
             [
                 '-12 hours',
                 new \DateTime('-12 hours'),
-                true,
+                false,
             ],
         ];
     }

--- a/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
+++ b/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Tests\Type;
+
+use AppBundle\Type\DateTimeArrayType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class DateTimeArrayTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        TypeTester::addType(DateTimeArrayType::DATE_TIME_ARRAY, DateTimeArrayType::class);
+    }
+
+    public function testEncodesData()
+    {
+        $mockTime = new \DateTime('2016-05-31 15:00:00');
+
+        $type = TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY);
+
+        $this->assertJsonStringEqualsJsonString(
+            $type->convertToDatabaseValue([$mockTime], $this->getMockForAbstractClass(AbstractPlatform::class)),
+            '["2016-05-31 15:00:00"]'
+        );
+    }
+
+    public function testParsesDBValue()
+    {
+        $string   = '2016-05-31 15:00:00';
+        $expected = new \DateTime($string);
+        $input    = json_encode([$string]);
+
+        $type = TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY);
+
+        $this->assertEquals(
+            $type->convertToPHPValue($input, $this->getMockForAbstractClass(AbstractPlatform::class)),
+            [$expected]
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /^The decode of the JSON string from the database \(\"(.*)\"\) failed due to the following error: "(.*)"\!$/
+     */
+    public function testCorruptedJSONString()
+    {
+        TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY)
+            ->convertToPHPValue('["1970-01-01 00:00:00]', $this->getMockForAbstractClass(AbstractPlatform::class));
+    }
+}
+
+abstract class TypeTester extends Type
+{
+}

--- a/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
+++ b/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
@@ -43,7 +43,7 @@ class DateTimeArrayTypeTest extends \PHPUnit_Framework_TestCase
 
         $type = TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY);
 
-        $this->assertEquals(
+        $this->assertSame(
             $type->convertToPHPValue($input, $this->getMockForAbstractClass(AbstractPlatform::class)),
             [$expected]
         );

--- a/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
+++ b/src/AppBundle/Tests/Type/DateTimeArrayTypeTest.php
@@ -41,12 +41,11 @@ class DateTimeArrayTypeTest extends \PHPUnit_Framework_TestCase
         $expected = new \DateTime($string);
         $input    = json_encode([$string]);
 
-        $type = TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY);
+        $type   = TypeTester::getType(DateTimeArrayType::DATE_TIME_ARRAY);
+        $result = $type->convertToPHPValue($input, $this->getMockForAbstractClass(AbstractPlatform::class));
 
-        $this->assertSame(
-            $type->convertToPHPValue($input, $this->getMockForAbstractClass(AbstractPlatform::class)),
-            [$expected]
-        );
+        $this->assertCount(1, $result);
+        $this->assertEquals($result[0], $expected);
     }
 
     /**

--- a/src/AppBundle/Type/DateTimeArrayType.php
+++ b/src/AppBundle/Type/DateTimeArrayType.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Custom DBAL type which formats a datetime object into the database's datetime (normally "Y-m-d H:i:s") format
+ * and serializes the whole dataset into a JSON array.
+ *
+ * Normally the array `type` will be used and the whole structure will be serialized and can't be parsed
+ * by any other service and it's more difficult to read and maintain the structure,
+ * so a simple JSON array will be used which improves readability.
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+final class DateTimeArrayType extends Type
+{
+    const DATE_TIME_ARRAY = 'date_time_array';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::DATE_TIME_ARRAY;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        $format = $platform->getDateTimeFormatString();
+
+        return json_encode(
+            array_map(function (\DateTime $dateTime) use ($format) {
+                return $dateTime->format($format);
+            }, $value)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException If the data decode fails.
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        $raw = json_decode($value, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new \RuntimeException(sprintf(
+                'The decode of the JSON string from the database ("%s") failed due to the following error: "%s"!',
+                $value,
+                json_last_error_msg()
+            ));
+        }
+
+        $dbFormat = $platform->getDateTimeFormatString();
+        return array_map(
+            function ($format) use ($dbFormat) {
+                return \DateTime::createFromFormat($dbFormat, $format);
+            },
+            $raw
+        );
+    }
+}

--- a/src/AppBundle/Type/DateTimeArrayType.php
+++ b/src/AppBundle/Type/DateTimeArrayType.php
@@ -76,6 +76,7 @@ final class DateTimeArrayType extends Type
         }
 
         $dbFormat = $platform->getDateTimeFormatString();
+
         return array_map(
             function ($format) use ($dbFormat) {
                 return \DateTime::createFromFormat($dbFormat, $format);

--- a/src/AppBundle/Type/DateTimeArrayType.php
+++ b/src/AppBundle/Type/DateTimeArrayType.php
@@ -84,4 +84,12 @@ final class DateTimeArrayType extends Type
             $raw
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/vagrant/hieradata/common.yaml
+++ b/vagrant/hieradata/common.yaml
@@ -73,6 +73,10 @@ sententiaregum::infrastructure::jobs::schedules:
     command: "php /var/www/sententiaregum/app/console sententiaregum:purge:pending-activations"
     user: vagrant
     hour: 5
+  cleanup_auth_attempt_data:
+    command: "php /var/www/sententiaregum/app/console sententiaregum:purge:ancient-auth-attempt-log-data"
+    user: vagrant
+    hour: 5
 
 # mailcatcher
 sententiaregum::infrastructure::mailcatcher::dest_ip: '0.0.0.0'


### PR DESCRIPTION
### Overview

the new implementation determines whether to submit an email or not which makes the whole evaluation more complex.
Furthermore the user's IP will be removed from the auth attempt log when the account will be logged in. A purger has been implemented in order to cleanup ancient data.
### Related tickets

resolves #237 
