### PR TITLE
Bug #233 implement a listener to avoid JSON errors in case of non-api request having a 404

### DIFF
--- a/src/AppBundle/EventListener/NotFoundResponseListener.php
+++ b/src/AppBundle/EventListener/NotFoundResponseListener.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * HTTP listener which handles 404 errors.
+ *
+ * If the request is an API request, the JSON will be rendered, but if it's an invalid request against the page, it will
+ * be redirected to the appropriate hashbang target.
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class NotFoundResponseListener implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException',
+        ];
+    }
+
+    /**
+     * Exception handler.
+     *
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $request = $event->getRequest();
+        $uri     = $request->getRequestUri();
+
+        // abort for API requests (fos_rest will take over) and non-404 exceptions
+        if (!$event->getException() instanceof NotFoundHttpException
+            || (bool) preg_match('/^\/api\/(.*)(\?(.*))?$/', $uri)
+        ) {
+            return;
+        }
+
+        // delegate to hashbangs
+        $event->setResponse(new RedirectResponse($this->getHashBangURL($uri)));
+    }
+
+    /**
+     * Transforms the URI into a hashbang url
+     *
+     * @param string $requestUri
+     *
+     * @return string
+     */
+    private function getHashBangURL(string $requestUri): string
+    {
+        // the slash after the `#` is not needed as the request_uri contains it's own slash as prefix
+        return sprintf('/#%s', $requestUri);
+    }
+}

--- a/src/AppBundle/EventListener/NotFoundResponseListener.php
+++ b/src/AppBundle/EventListener/NotFoundResponseListener.php
@@ -62,7 +62,7 @@ class NotFoundResponseListener implements EventSubscriberInterface
     }
 
     /**
-     * Transforms the URI into a hashbang url
+     * Transforms the URI into a hashbang url.
      *
      * @param string $requestUri
      *

--- a/src/AppBundle/Resources/config/listeners.yml
+++ b/src/AppBundle/Resources/config/listeners.yml
@@ -46,3 +46,7 @@ services:
       - "@translator"
     tags:
       - { name: kernel.event_subscriber }
+  app.listener.not_found_response:
+    class: AppBundle\EventListener\NotFoundResponseListener
+    tags:
+      - { name: kernel.event_subscriber }

--- a/src/AppBundle/Tests/Unit/EventListener/NotFoundResponseListenerTest.php
+++ b/src/AppBundle/Tests/Unit/EventListener/NotFoundResponseListenerTest.php
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AppBundle\Tests\Unit\EventListener;
 

--- a/src/AppBundle/Tests/Unit/EventListener/NotFoundResponseListenerTest.php
+++ b/src/AppBundle/Tests/Unit/EventListener/NotFoundResponseListenerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace AppBundle\Tests\Unit\EventListener;
+
+use AppBundle\EventListener\NotFoundResponseListener;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class NotFoundResponseListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param Request    $request
+     * @param \Exception $exception
+     *
+     * @dataProvider provideReplacementData
+     */
+    public function testReplaceResponse(Request $request, \Exception $exception, string $expected)
+    {
+        $listener = new NotFoundResponseListener();
+        $event    = new GetResponseForExceptionEvent(
+            $this->getMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+
+        $listener->onKernelException($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame($expected, $response->getTargetUrl());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideReplacementData(): array
+    {
+        return [
+            [
+                Request::create('/invalid_url'),
+                new NotFoundHttpException(),
+                '/#/invalid_url',
+            ],
+            [
+                Request::create('/invalid/url?foo=bar#blah'),
+                new NotFoundHttpException(),
+                '/#/invalid/url?foo=bar',
+            ],
+            [ // specification needed for this case as API should be a separated prefix
+                Request::create('/apifoo'),
+                new NotFoundHttpException(),
+                '/#/apifoo',
+            ],
+            [
+                Request::create('/blah#foo'),
+                new NotFoundHttpException(),
+                '/#/blah',
+            ],
+            [
+                Request::create('/blah?data'),
+                new NotFoundHttpException(),
+                '/#/blah?data',
+            ],
+            [
+                Request::create('/blah?data[]=foo&data[]=more_data'),
+                new NotFoundHttpException(),
+                '/#/blah?data[]=foo&data[]=more_data',
+            ],
+        ];
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param Request    $request
+     *
+     * @dataProvider provideAbortData
+     */
+    public function testAbortOnInvalidConditions(\Exception $exception, Request $request)
+    {
+        $listener = new NotFoundResponseListener();
+        $event    = new GetResponseForExceptionEvent(
+            $this->getMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+
+        $listener->onKernelException($event);
+        $this->assertNull($event->getResponse());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideAbortData(): array
+    {
+        return [
+            [
+                new AccessDeniedHttpException(),
+                Request::create('/invalid_url'),
+            ],
+            [
+                new NotFoundHttpException(),
+                Request::create('/api/invalid_url.json'),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Overview

The listener detects whether an API request is in progress or not. Unless and a 404 is the result, it will be redirected to the actual hashbang target:

`/any-url (404)` -> `/#/any-url`
`/any-url#useless-hashbang (404)` -> `/#/any-url`
`/any-url?foo (404)` -> `/#/any-url?foo`
### Related tickets

resolves #233 
