### PR TITLE
Support/Maintenance #335 solve dependency between suggestor chain and single suggestors properly to avoid explicit dependencies and tight coupling

### DIFF
--- a/src/AppBundle/AppBundle.php
+++ b/src/AppBundle/AppBundle.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 
 namespace AppBundle;
 
-use AppBundle\DependencyInjection\Compiler\ConfigureNotificatableCommandHandlersPass;
+use AppBundle\DependencyInjection\Compiler\AddSuggestorToNameSuggestionChainPass;
+use AppBundle\DependencyInjection\Compiler\ConfigureNotificatableServicesPass;
 use AppBundle\DependencyInjection\Compiler\ConnectChannelsWithDelegatorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -26,7 +27,8 @@ class AppBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new ConfigureNotificatableCommandHandlersPass());
+        $container->addCompilerPass(new ConfigureNotificatableServicesPass());
         $container->addCompilerPass(new ConnectChannelsWithDelegatorPass());
+        $container->addCompilerPass(new AddSuggestorToNameSuggestionChainPass());
     }
 }

--- a/src/AppBundle/DependencyInjection/AppExtension.php
+++ b/src/AppBundle/DependencyInjection/AppExtension.php
@@ -33,7 +33,7 @@ class AppExtension extends Extension
     {
         $fileLoader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        foreach (['services', 'validators', 'redis', 'listeners', 'repositories', 'commands', 'handlers', 'middlewares'] as $baseName) {
+        foreach (['services', 'validators', 'redis', 'listeners', 'repositories', 'commands', 'handlers', 'middlewares', 'suggestors'] as $baseName) {
             $fileLoader->load(sprintf('%s.yml', $baseName));
         }
     }

--- a/src/AppBundle/DependencyInjection/Compiler/AddSuggestorToNameSuggestionChainPass.php
+++ b/src/AppBundle/DependencyInjection/Compiler/AddSuggestorToNameSuggestionChainPass.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * AddSuggestorToNameSuggestionChainPass.
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class AddSuggestorToNameSuggestionChainPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LogicException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('app.user.registration.name_suggestor')) {
+            return;
+        }
+
+        $service = $container->getDefinition('app.user.registration.name_suggestor');
+        $tag     = 'app.registration.suggestor';
+        foreach ($container->findTaggedServiceIds($tag) as $id => $tags) {
+            if (count($tags) > 1) {
+                throw new \LogicException(sprintf(
+                    'The tag `%s` must be declared one time only!',
+                    $tag
+                ));
+            }
+
+            $service->addMethodCall('register', [new Reference($id)]);
+        }
+    }
+}

--- a/src/AppBundle/DependencyInjection/Compiler/ConfigureNotificatableServicesPass.php
+++ b/src/AppBundle/DependencyInjection/Compiler/ConfigureNotificatableServicesPass.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
  */
-class ConfigureNotificatableCommandHandlersPass implements CompilerPassInterface
+class ConfigureNotificatableServicesPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
@@ -38,7 +38,7 @@ class ConfigureNotificatableCommandHandlersPass implements CompilerPassInterface
 
         $templateMap = [];
         $notificator = $container->getDefinition('app.notification');
-        $tagName     = 'app.command_handler.notificatable';
+        $tagName     = 'app.service.notificatable';
         foreach ($container->findTaggedServiceIds($tagName) as $id => $tags) {
             if (count($tags) > 1) {
                 throw new \LogicException(sprintf(

--- a/src/AppBundle/Model/User/Util/NameSuggestion/ChainSuggestor.php
+++ b/src/AppBundle/Model/User/Util/NameSuggestion/ChainSuggestor.php
@@ -15,9 +15,7 @@ declare(strict_types=1);
 namespace AppBundle\Model\User\Util\NameSuggestion;
 
 use AppBundle\Model\User\UserReadRepositoryInterface;
-use AppBundle\Model\User\Util\NameSuggestion\Suggestor\DotReplacementSuggestor;
 use AppBundle\Model\User\Util\NameSuggestion\Suggestor\SuggestorInterface;
-use AppBundle\Model\User\Util\NameSuggestion\Suggestor\YearPostfixSuggestor;
 
 /**
  * Class that builds suggestions for usernames.

--- a/src/AppBundle/Model/User/Util/NameSuggestion/ChainSuggestor.php
+++ b/src/AppBundle/Model/User/Util/NameSuggestion/ChainSuggestor.php
@@ -44,9 +44,6 @@ class ChainSuggestor implements ChainSuggestorInterface
     public function __construct(UserReadRepositoryInterface $userRepository)
     {
         $this->userRepository = $userRepository;
-
-        $this->register(new YearPostfixSuggestor());
-        $this->register(new DotReplacementSuggestor());
     }
 
     /**
@@ -55,6 +52,8 @@ class ChainSuggestor implements ChainSuggestorInterface
     public function getPossibleSuggestions(string $name): array
     {
         $suggestions = array_merge(
+            [],
+            [], // array_merge expects at least 2 parameters
             ...array_map(function (SuggestorInterface $suggestor) use ($name) {
                 return $suggestor->getPossibleSuggestions($name);
             }, $this->suggestors)

--- a/src/AppBundle/Resources/config/handlers.yml
+++ b/src/AppBundle/Resources/config/handlers.yml
@@ -8,7 +8,7 @@ services:
       - "@validator"
     tags:
       - { name: command_handler, handles: AppBundle\Model\User\DTO\CreateUserDTO, method: __invoke }
-      - { name: app.command_handler.notificatable, template: "AppBundle:Email/Activation:activation" }
+      - { name: app.service.notificatable, template: "AppBundle:Email/Activation:activation" }
   app.handler.activate_account:
     class: AppBundle\Model\User\Handler\ActivateAccountHandler
     arguments:

--- a/src/AppBundle/Resources/config/listeners.yml
+++ b/src/AppBundle/Resources/config/listeners.yml
@@ -31,7 +31,7 @@ services:
       - "@app.redis.cluster.blocked_account"
     tags:
       - { name: kernel.event_subscriber }
-      - { name: app.command_handler.notificatable }
+      - { name: app.service.notificatable }
   app.listener.i18n_security_response:
     class: AppBundle\EventListener\I18nSecurityResponseListener
     arguments:

--- a/src/AppBundle/Resources/config/suggestors.yml
+++ b/src/AppBundle/Resources/config/suggestors.yml
@@ -1,0 +1,9 @@
+services:
+  app.user.registration.suggestor.year_postfix:
+    class: AppBundle\Model\User\Util\NameSuggestion\Suggestor\YearPostfixSuggestor
+    tags:
+      - { name: app.registration.suggestor }
+  app.user.registration.suggestor.dot_replacement:
+    class: AppBundle\Model\User\Util\NameSuggestion\Suggestor\DotReplacementSuggestor
+    tags:
+      - { name: app.registration.suggestor }

--- a/src/AppBundle/Tests/Unit/DependencyInjection/AppExtensionTest.php
+++ b/src/AppBundle/Tests/Unit/DependencyInjection/AppExtensionTest.php
@@ -27,7 +27,7 @@ class AppExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension->load([], $container);
         $resources = $container->getResources();
-        $this->assertCount(8, $resources);
+        $this->assertCount(9, $resources);
 
         $names = array_map(function (FileResource $resource) {
             $split = explode('/', $resource->getResource());
@@ -38,7 +38,7 @@ class AppExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(
             0,
             array_diff(
-                ['listeners.yml', 'commands.yml', 'redis.yml', 'repositories.yml', 'services.yml', 'validators.yml'],
+                ['listeners.yml', 'commands.yml', 'redis.yml', 'repositories.yml', 'services.yml', 'validators.yml', 'suggestors.yml'],
                 $names
             )
         );

--- a/src/AppBundle/Tests/Unit/DependencyInjection/Compiler/AddSuggestorToNameSuggestionChainPassTest.php
+++ b/src/AppBundle/Tests/Unit/DependencyInjection/Compiler/AddSuggestorToNameSuggestionChainPassTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sententiaregum project.
+ *
+ * (c) Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ * (c) Ben Bieler <benjaminbieler2014@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use AppBundle\DependencyInjection\Compiler\AddSuggestorToNameSuggestionChainPass;
+use AppBundle\Model\User\Util\NameSuggestion\ChainSuggestor;
+use AppBundle\Model\User\Util\NameSuggestion\Suggestor\YearPostfixSuggestor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddSuggestorToNameSuggestionChainPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The tag `app.registration.suggestor` must be declared one time only!
+     */
+    public function testMultipleTagDeclarations()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddSuggestorToNameSuggestionChainPass());
+
+        $container->setDefinition('app.user.registration.name_suggestor', new Definition(ChainSuggestor::class));
+        $suggestor = new Definition(YearPostfixSuggestor::class);
+        $suggestor->addTag('app.registration.suggestor', []);
+        $suggestor->addTag('app.registration.suggestor', []);
+
+        $container->setDefinition('suggestor', $suggestor);
+        $container->compile();
+    }
+
+    public function testAddSuggestorToChain()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddSuggestorToNameSuggestionChainPass());
+
+        $container->setDefinition('app.user.registration.name_suggestor', new Definition(ChainSuggestor::class));
+        $suggestor = new Definition(YearPostfixSuggestor::class);
+        $suggestor->addTag('app.registration.suggestor', []);
+
+        $container->setDefinition('suggestor', $suggestor);
+        $container->compile();
+
+        $chain = $container->getDefinition('app.user.registration.name_suggestor');
+        self::assertCount(1, $chain->getMethodCalls());
+
+        $call = $chain->getMethodCalls()[0];
+        self::assertSame('register', $call[0]);
+        self::assertCount(1, $call[1]);
+        self::assertInstanceOf(Reference::class, $call[1][0]);
+        self::assertSame('suggestor', (string) $call[1][0]);
+    }
+}

--- a/src/AppBundle/Tests/Unit/DependencyInjection/Compiler/ConfigureNotificatableServicesPassTest.php
+++ b/src/AppBundle/Tests/Unit/DependencyInjection/Compiler/ConfigureNotificatableServicesPassTest.php
@@ -14,22 +14,22 @@ declare(strict_types=1);
 
 namespace AppBundle\Tests\Unit\DependencyInjection\Compiler;
 
-use AppBundle\DependencyInjection\Compiler\ConfigureNotificatableCommandHandlersPass;
+use AppBundle\DependencyInjection\Compiler\ConfigureNotificatableServicesPass;
 use AppBundle\Model\User\Handler\CreateUserHandler;
 use AppBundle\Service\Notification\ChannelDelegatingNotificator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ConfigureNotificatableCommandHandlersPassTest extends \PHPUnit_Framework_TestCase
+class ConfigureNotificatableServicesPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testMissingDefinition()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new ConfigureNotificatableCommandHandlersPass());
+        $container->addCompilerPass(new ConfigureNotificatableServicesPass());
 
         $definition = new Definition(CreateUserHandler::class); // we use the user handler for testing purposes here
         $definition->addTag(
-            'app.command_handler.notificatable',
+            'app.service.notificatable',
             ['template' => 'AppBundle:Email/Activation:activation']
         );
 
@@ -42,20 +42,20 @@ class ConfigureNotificatableCommandHandlersPassTest extends \PHPUnit_Framework_T
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage The tag `app.command_handler.notificatable` must be declared one time only!
+     * @expectedExceptionMessage The tag `app.service.notificatable` must be declared one time only!
      */
     public function testDeclareTagMultipleTimes()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new ConfigureNotificatableCommandHandlersPass());
+        $container->addCompilerPass(new ConfigureNotificatableServicesPass());
 
         $definition = new Definition(CreateUserHandler::class); // we use the user handler for testing purposes here
         $definition->addTag(
-            'app.command_handler.notificatable',
+            'app.service.notificatable',
             ['template' => 'AppBundle:Email/Activation:activation']
         );
         $definition->addTag(
-            'app.command_handler.notificatable',
+            'app.service.notificatable',
             ['template' => 'AppBundle:Email/Activation:activation']
         );
 
@@ -67,11 +67,11 @@ class ConfigureNotificatableCommandHandlersPassTest extends \PHPUnit_Framework_T
     public function testConnectNotificatorServiceWithHandler()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new ConfigureNotificatableCommandHandlersPass());
+        $container->addCompilerPass(new ConfigureNotificatableServicesPass());
 
         $definition = new Definition(CreateUserHandler::class); // we use the user handler for testing purposes here
         $definition->addTag(
-            'app.command_handler.notificatable',
+            'app.service.notificatable',
             ['template' => 'AppBundle:Email/Activation:activation']
         );
 
@@ -99,11 +99,11 @@ class ConfigureNotificatableCommandHandlersPassTest extends \PHPUnit_Framework_T
     public function testNoTemplateIsPresentAsTagAttribute()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new ConfigureNotificatableCommandHandlersPass());
+        $container->addCompilerPass(new ConfigureNotificatableServicesPass());
 
         $definition = new Definition(CreateUserHandler::class); // we use the user handler for testing purposes here
         $definition->addTag(
-            'app.command_handler.notificatable',
+            'app.service.notificatable',
             []
         );
 
@@ -117,5 +117,6 @@ class ConfigureNotificatableCommandHandlersPassTest extends \PHPUnit_Framework_T
         self::assertCount(1, $calls = $container->getDefinition('app.handler.create_user')->getMethodCalls());
         self::assertCount(0, $container->getDefinition('app.notification')->getArgument(1));
         self::assertSame((string) $calls[0][0], 'setNotificator');
+        self::assertSame((string) $calls[0][1][0], 'app.notification');
     }
 }


### PR DESCRIPTION
### Overview

refactoring of the name suggestion service: the internally used classes which generate certain suggestions for a username shouldn't be declared as explicit dependency in the actual service.
### Related tickets

resolves #335 
