### PR TITLE
Refactor #342 refactor internal user state as `locked` is basically a state transition

### DIFF
--- a/src/AppBundle/DataFixtures/ORM/AdminFixture.php
+++ b/src/AppBundle/DataFixtures/ORM/AdminFixture.php
@@ -38,7 +38,7 @@ class AdminFixture implements ProductionFixtureInterface, DependentFixtureInterf
         $adminRole      = $roleRepository->findOneBy(['role' => 'ROLE_ADMIN']);
 
         $admin = User::create('admin', '123456', 'admin@sententiaregum.dev', $passwordHasher);
-        $admin->modifyActivationStatus(User::STATE_APPROVED);
+        $admin->performStateTransition(User::STATE_APPROVED);
         $admin->addRole($adminRole);
         $admin->addRole($userRole);
         $admin->updateLastAction();

--- a/src/AppBundle/DataFixtures/ORM/UserFixture.php
+++ b/src/AppBundle/DataFixtures/ORM/UserFixture.php
@@ -36,20 +36,20 @@ class UserFixture implements FixtureInterface, DependentFixtureInterface
         $userRole       = $manager->getRepository('Account:Role')->findOneBy(['role' => 'ROLE_USER']);
 
         $user1 = User::create('Ma27', '72aM', 'Ma27@sententiaregum.dev', $passwordHasher);
-        $user1->modifyActivationStatus(User::STATE_APPROVED);
+        $user1->performStateTransition(User::STATE_APPROVED);
         $user1->addRole($userRole);
         $user1->updateLastAction();
         $user1->modifyUserLocale('de');
 
         $user2 = User::create('benbieler', 'releibneb', 'benbieler@sententiaregum.dev', $passwordHasher);
-        $user2->modifyActivationStatus(User::STATE_APPROVED);
+        $user2->performStateTransition(User::STATE_APPROVED);
         $user2->addRole($userRole);
         $user2->updateLastAction();
 
         $locked = User::create('anonymus', 'sumynona', 'anonymus@example.org', $passwordHasher);
-        $locked->modifyActivationStatus(User::STATE_APPROVED);
+        $locked->performStateTransition(User::STATE_APPROVED);
         $locked->addRole($userRole);
-        $locked->lock();
+        $locked->performStateTransition(User::STATE_LOCKED);
         $locked->updateLastAction();
 
         $user2->addFollowing($user1);

--- a/src/AppBundle/EventListener/IncompleteUserCheckListener.php
+++ b/src/AppBundle/EventListener/IncompleteUserCheckListener.php
@@ -59,6 +59,10 @@ class IncompleteUserCheckListener
 
         if ($isLocked || $isNonApproved || $this->temporaryBlockedAccountProvider->isAccountTemporaryBlocked($user->getId())) {
             switch (true) {
+                // NOTE: it's necessary to check `locked` at first now since `locked` is a state transition that can't be done
+                // if a user is non-approved, but can be done if the user's approved. Therefore
+                // it's safe to rely on $isLocked without looking at `$isNonApproved`, but $isNonApproved is false
+                // if the user's locked since this is another state.
                 case $isLocked:
                     $message = 'BACKEND_AUTH_LOCKED';
                     break;

--- a/src/AppBundle/EventListener/IncompleteUserCheckListener.php
+++ b/src/AppBundle/EventListener/IncompleteUserCheckListener.php
@@ -55,15 +55,15 @@ class IncompleteUserCheckListener
         $user = $event->getUser();
 
         $isLocked      = $user->isLocked();
-        $isNonApproved = $user->getActivationStatus() !== User::STATE_APPROVED;
+        $isNonApproved = !$user->isApproved();
 
         if ($isLocked || $isNonApproved || $this->temporaryBlockedAccountProvider->isAccountTemporaryBlocked($user->getId())) {
             switch (true) {
-                case $isNonApproved:
-                    $message = 'BACKEND_AUTH_NON_APPROVED';
-                    break;
                 case $isLocked:
                     $message = 'BACKEND_AUTH_LOCKED';
+                    break;
+                case $isNonApproved:
+                    $message = 'BACKEND_AUTH_NON_APPROVED';
                     break;
                 default:
                     $message = 'BACKEND_AUTH_BLOCKED';

--- a/src/AppBundle/Model/User/Handler/ActivateAccountHandler.php
+++ b/src/AppBundle/Model/User/Handler/ActivateAccountHandler.php
@@ -77,7 +77,7 @@ final class ActivateAccountHandler
             throw new UserActivationException();
         }
 
-        $user->modifyActivationStatus(User::STATE_APPROVED, $activateAccountDTO->activationKey);
+        $user->performStateTransition(User::STATE_APPROVED, $activateAccountDTO->activationKey);
 
         // the role needs to be added during approval since a non-approved user must not have any role in the system.
         // Furthermore it leads to technical issues when running the purger as the roles may cause a constraint violation

--- a/src/AppBundle/Model/User/User.php
+++ b/src/AppBundle/Model/User/User.php
@@ -400,6 +400,7 @@ class User implements UserInterface, Serializable
     {
         return $this->state === self::STATE_APPROVED;
     }
+
     /**
      * Set aboutText.
      *

--- a/src/AppBundle/Model/User/User.php
+++ b/src/AppBundle/Model/User/User.php
@@ -41,6 +41,7 @@ class User implements UserInterface, Serializable
 {
     const STATE_NEW                   = 'new';
     const STATE_APPROVED              = 'approved';
+    const STATE_LOCKED                = 'locked';
     const MAX_FAILED_ATTEMPTS_FROM_IP = 3;
     const FAILED_AUTH_POOL            = 'failed_auths';
     const AUTH_ATTEMPT_POOL           = 'auth_attempts';
@@ -106,13 +107,6 @@ class User implements UserInterface, Serializable
      * @ORM\Column(name="state", type="string")
      */
     private $state;
-
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="locked", type="boolean")
-     */
-    private $locked = false;
 
     /**
      * @var string
@@ -229,7 +223,7 @@ class User implements UserInterface, Serializable
         $this->registrationDate      = new DateTime();
         $this->lastAction            = new DateTime();
 
-        $this->modifyActivationStatus(self::STATE_NEW);
+        $this->performStateTransition(self::STATE_NEW);
     }
 
     /**
@@ -343,26 +337,36 @@ class User implements UserInterface, Serializable
      * @param string $key
      *
      * @throws \InvalidArgumentException If no activation key is given.
+     * @throws \LogicException If a locked user receives an invalid state transition.
      *
      * @return User
      */
-    public function modifyActivationStatus($state, $key = null): self
+    public function performStateTransition(string $state, string $key = null): self
     {
-        if (!in_array($state, [self::STATE_NEW, self::STATE_APPROVED], true)) {
+        if (!in_array($state, [self::STATE_NEW, self::STATE_APPROVED, self::STATE_LOCKED], true)) {
             throw new \InvalidArgumentException('Invalid state!');
         }
 
-        $this->state = (string) $state;
+        switch ($state) {
+            case self::STATE_APPROVED:
+                if (self::STATE_NEW === $this->state) {
+                    if (($activationInfo = $this->pendingActivation) && $key !== $activationInfo->getKey()) {
+                        throw new \InvalidArgumentException('Invalid activation key given!');
+                    }
 
-        if (self::STATE_APPROVED === $this->state) {
-            if (($activationInfo = $this->pendingActivation) && $key !== $activationInfo->getKey()) {
-                throw new \InvalidArgumentException('Invalid activation key given!');
-            }
-
-            $this->removeActivationKey();
-        } else {
-            $this->pendingActivation = new PendingActivation($this->getRegistrationDate());
+                    $this->removeActivationKey();
+                }
+                break;
+            case self::STATE_LOCKED:
+                if (self::STATE_NEW === $this->state) {
+                    throw new \LogicException('Only approved users can be locked!');
+                }
+                break;
+            default:
+                $this->pendingActivation = new PendingActivation($this->getRegistrationDate());
         }
+
+        $this->state = $state;
 
         return $this;
     }
@@ -372,33 +376,9 @@ class User implements UserInterface, Serializable
      *
      * @return string
      */
-    public function getActivationStatus(): string
+    public function getState(): string
     {
         return $this->state;
-    }
-
-    /**
-     * Locks the user.
-     *
-     * @return $this
-     */
-    public function lock()
-    {
-        $this->locked = true;
-
-        return $this;
-    }
-
-    /**
-     * Unlocks the user.
-     *
-     * @return $this
-     */
-    public function unlock()
-    {
-        $this->locked = false;
-
-        return $this;
     }
 
     /**
@@ -408,9 +388,18 @@ class User implements UserInterface, Serializable
      */
     public function isLocked(): bool
     {
-        return $this->locked;
+        return $this->state === self::STATE_LOCKED;
     }
 
+    /**
+     * Checks if the current user is approved.
+     *
+     * @return bool
+     */
+    public function isApproved(): bool
+    {
+        return $this->state === self::STATE_APPROVED;
+    }
     /**
      * Set aboutText.
      *
@@ -442,16 +431,10 @@ class User implements UserInterface, Serializable
      *
      * @return User
      */
-    public function storeUniqueActivationKeyForNonApprovedUser($activationKey): self
+    public function storeUniqueActivationKeyForNonApprovedUser(string $activationKey): self
     {
-        if (self::STATE_APPROVED === $this->getActivationStatus()) {
+        if (self::STATE_APPROVED === $this->state || self::STATE_LOCKED === $this->state) {
             throw new \LogicException('Approved users cannot have an activation key!');
-        }
-
-        if (empty($activationKey)) {
-            $problem = 'Cannot set empty activation key! Please call "removeActivationKey()" instead for the removal of the activation key!';
-
-            throw new \LogicException($problem);
         }
 
         $this->pendingActivation->setKey($activationKey);
@@ -466,7 +449,7 @@ class User implements UserInterface, Serializable
      */
     public function removeActivationKey(): self
     {
-        if (self::STATE_APPROVED !== $this->getActivationStatus()) {
+        if (self::STATE_NEW !== $this->state) {
             throw new \LogicException('Only approved users can remove activation keys!');
         }
 
@@ -487,8 +470,8 @@ class User implements UserInterface, Serializable
      */
     public function addRole(Role $role): self
     {
-        if ($this->getActivationStatus() === static::STATE_NEW) {
-            throw new \InvalidArgumentException('Cannot attach role on non-approved user!');
+        if (!$this->isApproved()) {
+            throw new \InvalidArgumentException('Cannot attach role on non-approved or locked user!');
         }
 
         if ($this->hasRole($role)) {
@@ -565,12 +548,16 @@ class User implements UserInterface, Serializable
      *
      * @param User $user
      *
+     * @throws \LogicException If the following user doesn't exist.
+     *
      * @return User
      */
     public function removeFollowing(User $user): self
     {
         if (!$this->follows($user)) {
-            throw new \LogicException('Cannot remove relation with invalid user "%s"!', $user->getUsername());
+            throw new \LogicException(sprintf(
+                'Cannot remove relation with invalid user "%s"!', $user->getUsername()
+            ));
         }
 
         $this->following->removeElement($user);
@@ -722,7 +709,6 @@ class User implements UserInterface, Serializable
             $this->registrationDate->getTimestamp(),
             $this->apiKey,
             $this->state,
-            $this->locked,
             $this->aboutText,
             $this->getRoles(),
             $this->getFollowing(),
@@ -748,12 +734,11 @@ class User implements UserInterface, Serializable
         $this->registrationDate      = new DateTime(sprintf('@%s', $data[5]));
         $this->apiKey                = $data[6];
         $this->state                 = $data[7];
-        $this->locked                = $data[8];
-        $this->aboutText             = $data[9];
-        $this->roles                 = new ArrayCollection($data[10]);
-        $this->following             = new ArrayCollection($data[11]);
-        $this->authentications       = new ArrayCollection($data[12]);
-        $this->failedAuthentications = new ArrayCollection($data[13]);
+        $this->aboutText             = $data[8];
+        $this->roles                 = new ArrayCollection($data[9]);
+        $this->following             = new ArrayCollection($data[10]);
+        $this->authentications       = new ArrayCollection($data[11]);
+        $this->failedAuthentications = new ArrayCollection($data[12]);
     }
 
     /**

--- a/src/AppBundle/Model/User/User.php
+++ b/src/AppBundle/Model/User/User.php
@@ -337,7 +337,7 @@ class User implements UserInterface, Serializable
      * @param string $key
      *
      * @throws \InvalidArgumentException If no activation key is given.
-     * @throws \LogicException If a locked user receives an invalid state transition.
+     * @throws \LogicException           If a locked user receives an invalid state transition.
      *
      * @return User
      */

--- a/src/AppBundle/Tests/Unit/EventListener/IncompleteUserCheckListenerTest.php
+++ b/src/AppBundle/Tests/Unit/EventListener/IncompleteUserCheckListenerTest.php
@@ -29,8 +29,8 @@ class IncompleteUserCheckListenerTest extends \PHPUnit_Framework_TestCase
     public function testUserIsLocked()
     {
         $user = User::create('Ma27', '123456', 'Ma27@sententiaregum.dev', new PhpPasswordHasher());
-        $user->modifyActivationStatus(User::STATE_APPROVED);
-        $user->lock();
+        $user->performStateTransition(User::STATE_APPROVED);
+        $user->performStateTransition(User::STATE_LOCKED);
 
         $hook = new IncompleteUserCheckListener($this->getMock(BlockedAccountReadInterface::class));
         $hook->validateUserOnAuthentication(new OnAuthenticationEvent($user));
@@ -50,25 +50,12 @@ class IncompleteUserCheckListenerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Ma27\ApiKeyAuthenticationBundle\Exception\CredentialException
-     * @expectedExceptionMessage BACKEND_AUTH_NON_APPROVED
-     */
-    public function testUserIsNonApprovedAndLocked()
-    {
-        $user = User::create('Ma27', '123456', 'Ma27@sententiaregum.dev', new PhpPasswordHasher());
-        $user->lock();
-
-        $hook = new IncompleteUserCheckListener($this->getMock(BlockedAccountReadInterface::class));
-        $hook->validateUserOnAuthentication(new OnAuthenticationEvent($user));
-    }
-
-    /**
-     * @expectedException \Ma27\ApiKeyAuthenticationBundle\Exception\CredentialException
      * @expectedExceptionMessage BACKEND_AUTH_BLOCKED
      */
     public function testAccountIsTemporaryBlocked()
     {
         $user = User::create('Ma27', '123456', 'Ma27@sententiaregum.dev', new PhpPasswordHasher());
-        $user->modifyActivationStatus(User::STATE_APPROVED);
+        $user->performStateTransition(User::STATE_APPROVED);
 
         $provider = $this->getMock(BlockedAccountReadInterface::class);
         $provider

--- a/src/AppBundle/Tests/Unit/Model/User/Handler/ActivateAccountHandlerTest.php
+++ b/src/AppBundle/Tests/Unit/Model/User/Handler/ActivateAccountHandlerTest.php
@@ -106,7 +106,7 @@ class ActivateAccountHandlerTest extends \PHPUnit_Framework_TestCase
     public function testActivateAccount()
     {
         $user = User::create('Ma27', '123456', 'Ma27@sententiaregum.dev', new PhpPasswordHasher());
-        $user->modifyActivationStatus(User::STATE_NEW);
+        $user->performStateTransition(User::STATE_NEW);
         $user->storeUniqueActivationKeyForNonApprovedUser('key');
 
         $writeRepository = $this->getMock(UserWriteRepositoryInterface::class);
@@ -139,7 +139,7 @@ class ActivateAccountHandlerTest extends \PHPUnit_Framework_TestCase
         $handler($dto);
 
         $this->assertTrue($user->hasRole($role));
-        $this->assertSame(User::STATE_APPROVED, $user->getActivationStatus());
+        $this->assertSame(User::STATE_APPROVED, $user->getState());
         $this->assertNull($user->getPendingActivation());
     }
 }


### PR DESCRIPTION
### Overview

refactored user model to have better state transitions:

- modify behavior to handle the new state transitions properly
- refactor public API of the `User` aggregate
- improve coverage

### Related issues

resolves #342 